### PR TITLE
fix for apiv1 getAll

### DIFF
--- a/src/main/java/com/serli/open/data/poitiers/repository/OpenDataRepositoryV1.java
+++ b/src/main/java/com/serli/open/data/poitiers/repository/OpenDataRepositoryV1.java
@@ -125,7 +125,7 @@ public class OpenDataRepositoryV1 extends ElasticSearchRepository {
                 "   \"query\": {\n" +
                 "      \"match_all\": {}\n" +
                 "   },\n" +
-                "   \"size\": " + Integer.MAX_VALUE + "\n" +
+                "   \"size\": " + 10000 + "\n" +
                 "}";
         SearchResult searchResult = performSearchOnType(query, elasticType);
 


### PR DESCRIPTION
Size of query (Integer.MAX_VALUE) is too high for searchbox addon
